### PR TITLE
Add loading and error from evergreen to DataWrapper

### DIFF
--- a/src/components/atoms/ErrorMessage.tsx
+++ b/src/components/atoms/ErrorMessage.tsx
@@ -1,0 +1,29 @@
+import { InlineAlert } from 'evergreen-ui';
+import React from 'react';
+import { Text, Pane } from 'evergreen-ui';
+
+export type ErrorMessageProps = {
+    size?: 300 | 400 | 500 | 600;
+    message?: string;
+    moreInfo?: string;
+};
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ message = 'Error :(', moreInfo, size = 400 }) => {
+    return (
+        <Pane
+            display="flex"
+            flexDirection="column"
+            width="100%"
+            height="100%"
+            justifyContent="center"
+            alignItems="center"
+        >
+            <InlineAlert intent="danger" size={size}>
+                {message}
+            </InlineAlert>
+            {moreInfo && <Text size={size}>{moreInfo}</Text>}
+        </Pane>
+    );
+};
+
+export default ErrorMessage;

--- a/src/components/atoms/ErrorMessage.tsx
+++ b/src/components/atoms/ErrorMessage.tsx
@@ -1,6 +1,5 @@
-import { InlineAlert } from 'evergreen-ui';
 import React from 'react';
-import { Text, Pane } from 'evergreen-ui';
+import { Text, Pane, InlineAlert } from 'evergreen-ui';
 
 export type ErrorMessageProps = {
     size?: 300 | 400 | 500 | 600;

--- a/src/components/atoms/Loading.tsx
+++ b/src/components/atoms/Loading.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Spinner, Pane } from 'evergreen-ui';
+
+export type LoadingProps = {
+    size?: number;
+};
+
+const Loading: React.FC<LoadingProps> = ({ size = 12 }) => {
+    return (
+        <Pane width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+            <Spinner size={size} />
+        </Pane>
+    );
+};
+
+export default Loading;

--- a/src/components/molecules/DataWrapper.tsx
+++ b/src/components/molecules/DataWrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DocumentNode, useQuery } from '@apollo/client';
-import { InlineAlert, Pane, Spinner } from 'evergreen-ui';
+import Loading from '../atoms/Loading';
+import ErrorMessage from '../atoms/ErrorMessage';
 
 /**
  * @param T The raw output of the GraphQL query.
@@ -12,14 +13,6 @@ export type DataWrapperProps<T, U> = {
     mappingFunction: (data: T) => U;
 };
 
-const CenterPane: React.FC = ({ children }) => {
-    return (
-        <Pane width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
-            {children}
-        </Pane>
-    );
-};
-
 /**
  * This component is responsible for retrieving and mapping a GraphQL query to the expected input to the
  * child function. It is a generic component to support arbitrary children.
@@ -29,27 +22,15 @@ const DataWrapper = <T, U>(props: DataWrapperProps<T, U>): JSX.Element => {
     const { loading, error, data } = useQuery<T>(props.query);
 
     if (loading) {
-        return (
-            <CenterPane>
-                <Spinner />
-            </CenterPane>
-        );
+        return <Loading />;
     }
 
     if (error) {
-        return (
-            <CenterPane>
-                <InlineAlert intent="danger">Vi finner ikke dataen du leter etter.</InlineAlert>
-            </CenterPane>
-        );
+        return <ErrorMessage message="Det oppsto en feil under henting av data" moreInfo={error.message} />;
     }
 
     if (!data) {
-        return (
-            <CenterPane>
-                <InlineAlert intent="danger">Ingen data mottatt fra serveren.</InlineAlert>
-            </CenterPane>
-        );
+        return <ErrorMessage message="Ingen data mottatt fra serveren." />;
     }
 
     return props.children(props.mappingFunction(data));

--- a/src/components/molecules/DataWrapper.tsx
+++ b/src/components/molecules/DataWrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DocumentNode, useQuery } from '@apollo/client';
+import { InlineAlert, Pane, Spinner } from 'evergreen-ui';
 
 /**
  * @param T The raw output of the GraphQL query.
@@ -11,23 +12,44 @@ export type DataWrapperProps<T, U> = {
     mappingFunction: (data: T) => U;
 };
 
+const CenterPane: React.FC = ({ children }) => {
+    return (
+        <Pane width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+            {children}
+        </Pane>
+    );
+};
+
 /**
  * This component is responsible for retrieving and mapping a GraphQL query to the expected input to the
  * child function. It is a generic component to support arbitrary children.
  */
+
 const DataWrapper = <T, U>(props: DataWrapperProps<T, U>): JSX.Element => {
     const { loading, error, data } = useQuery<T>(props.query);
 
     if (loading) {
-        return <p>Loading… ⏳</p>;
+        return (
+            <CenterPane>
+                <Spinner />
+            </CenterPane>
+        );
     }
 
     if (error) {
-        return <p>Error: {error.message}</p>;
+        return (
+            <CenterPane>
+                <InlineAlert intent="danger">Vi finner ikke dataen du leter etter.</InlineAlert>
+            </CenterPane>
+        );
     }
 
     if (!data) {
-        return <p>No data retrieved from backend.</p>;
+        return (
+            <CenterPane>
+                <InlineAlert intent="danger">Ingen data mottatt fra serveren.</InlineAlert>
+            </CenterPane>
+        );
     }
 
     return props.children(props.mappingFunction(data));

--- a/src/stories/ErrorMessage.stories.tsx
+++ b/src/stories/ErrorMessage.stories.tsx
@@ -21,7 +21,6 @@ Primary.argTypes = {
 };
 
 export const Secondary = Template.bind({});
-
 Secondary.args = { size: 400, message: 'Error message', moreInfo: 'This is more info about the error' };
 Secondary.argTypes = {
     size: sizeControl,

--- a/src/stories/ErrorMessage.stories.tsx
+++ b/src/stories/ErrorMessage.stories.tsx
@@ -20,8 +20,12 @@ Primary.argTypes = {
     size: sizeControl,
 };
 
+Primary.storyName = 'Without details';
+
 export const Secondary = Template.bind({});
 Secondary.args = { size: 400, message: 'Error message', moreInfo: 'This is more info about the error' };
 Secondary.argTypes = {
     size: sizeControl,
 };
+
+Secondary.storyName = 'With details';

--- a/src/stories/ErrorMessage.stories.tsx
+++ b/src/stories/ErrorMessage.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import ErrorMessage, { ErrorMessageProps } from '../components/atoms/ErrorMessage';
+import { Story } from '@storybook/react';
+
+export default {
+    title: 'Atom/ErrorMessage',
+    component: ErrorMessage,
+} as Meta;
+
+const Template: Story<ErrorMessageProps> = (args) => (
+    <ErrorMessage message={args.message} moreInfo={args.moreInfo} size={args.size} />
+);
+
+const sizeControl = { control: { type: 'radio', options: [300, 400, 500, 600] } };
+
+export const Primary = Template.bind({});
+Primary.args = { size: 400, message: 'Error message' };
+Primary.argTypes = {
+    size: sizeControl,
+};
+
+export const Secondary = Template.bind({});
+
+Secondary.args = { size: 400, message: 'Error message', moreInfo: 'This is more info about the error' };
+Secondary.argTypes = {
+    size: sizeControl,
+};

--- a/src/stories/Loading.stories.tsx
+++ b/src/stories/Loading.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import Loading, { LoadingProps } from '../components/atoms/Loading';
+import { Story } from '@storybook/react';
+
+export default {
+    title: 'Atom/Loading',
+    component: Loading,
+} as Meta;
+
+const Template: Story<LoadingProps> = (args) => <Loading size={args.size} />;
+
+export const Primary = Template.bind({});
+
+Primary.args = { size: 50 };
+Primary.argTypes = {
+    size: { control: { type: 'range', min: 10, max: 100, step: 1 } },
+};


### PR DESCRIPTION
Closes #50 

DataWrapper will now handle loading and error messages from GraphQL. This will be displayed on the dashboard in DashboardItems.