### PR TITLE
Use random data source name

### DIFF
--- a/src/mockdata/mocks.ts
+++ b/src/mockdata/mocks.ts
@@ -19,7 +19,7 @@ export const makeMetadata = () => {
     for (let i = 0; i < 10; i++) {
         allMetadata.push({
             id: faker.random.uuid(),
-            name: DataSourceName.MET_API_FORECAST,
+            name: faker.random.arrayElement(Object.values(DataSourceName)),
             description: faker.lorem.paragraph(),
             published: faker.date.recent().toString(),
             source: faker.internet.url(),


### PR DESCRIPTION
Closes #83 
Faker is now used to get a random API-name from the mocking service instead of just using a single one.