### PR TITLE
Add mock data for preview and make use of the visualisation enum

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import VisualisationEditor from './components/organisms/VisualisationEditor';
 import NotFound from './components/organisms/NotFound';
 
 const client = new ApolloClient({
-    uri: process.env.REACT_APP_GRAPHQL_ENDPOINT, // `https://sintef01.azurewebsites.net/graphql`, //
+    uri: process.env.REACT_APP_GRAPHQL_ENDPOINT,
     cache,
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import VisualisationEditor from './components/organisms/VisualisationEditor';
 import NotFound from './components/organisms/NotFound';
 
 const client = new ApolloClient({
-    uri: process.env.REACT_APP_GRAPHQL_ENDPOINT,
+    uri: process.env.REACT_APP_GRAPHQL_ENDPOINT, // `https://sintef01.azurewebsites.net/graphql`, //
     cache,
 });
 

--- a/src/components/molecules/DataResultItem.tsx
+++ b/src/components/molecules/DataResultItem.tsx
@@ -54,7 +54,6 @@ const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tag
                                         width={parent.width}
                                         height={height > 0 ? height : parent.height}
                                         data={timeEntryMockData}
-                                        thresholdValue={undefined}
                                         yLabel="Threshold chart"
                                     />
                                 );
@@ -63,7 +62,6 @@ const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tag
                         }
                     }}
                 </ParentSize>
-                {/*<Text>{visualisationType}</Text>*/}
             </Pane>
         </Card>
     );

--- a/src/components/molecules/DataResultItem.tsx
+++ b/src/components/molecules/DataResultItem.tsx
@@ -35,7 +35,7 @@ const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tag
                 <Heading marginBottom="1rem">Forslag til visualisering</Heading>
                 <ParentSize>
                     {(parent) => {
-                        const height = (parent.height ?? 288) - 40;
+                        const height = parent.height - 40;
                         switch (visualisationType) {
                             case VisualisationType.LINE:
                                 return (

--- a/src/components/molecules/DataResultItem.tsx
+++ b/src/components/molecules/DataResultItem.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
-import { Card, Pane, Heading, Text } from 'evergreen-ui';
+import { Card, Heading, Pane, Text } from 'evergreen-ui';
 import DatasetInfoBox from '../atoms/DatasetInfoBox';
+import { ParentSize } from '@visx/responsive';
+import ThresholdChart from '../charts/ThresholdChart';
+import LineChart from '../charts/LineChart';
+import mockTimeEntry from '../../mockdata/mockTimeEntry';
+import { VisualisationType } from '../../types/Metadata';
 
 export type DataResultItemProps = {
-    visualisationType: string;
+    visualisationType: VisualisationType;
     title: string;
     description: string;
     tags: string[];
 };
 
 const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tags, visualisationType }) => {
+    const timeEntryMockData = mockTimeEntry(100, undefined);
+
     return (
         <Card
             width="100%"
@@ -26,8 +33,37 @@ const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tag
             </Pane>
             <Pane flex="2">
                 <Heading marginBottom="1rem">Forslag til visualisering</Heading>
-                {/* The template graph will go here */}
-                <Text>{visualisationType}</Text>
+                <ParentSize>
+                    {(parent) => {
+                        const height = (parent.height ?? 288) - 40;
+                        switch (visualisationType) {
+                            case VisualisationType.LINE:
+                                return (
+                                    <LineChart
+                                        width={parent.width}
+                                        height={height > 0 ? height : parent.height}
+                                        data={timeEntryMockData}
+                                        yLabel="Line chart"
+                                        strokeColor="#66CCCC"
+                                        colorBottom="#E0EEEE"
+                                    />
+                                );
+                            case VisualisationType.THRESHOLD:
+                                return (
+                                    <ThresholdChart
+                                        width={parent.width}
+                                        height={height > 0 ? height : parent.height}
+                                        data={timeEntryMockData}
+                                        thresholdValue={undefined}
+                                        yLabel="Threshold chart"
+                                    />
+                                );
+                            default:
+                                return <Text>{visualisationType}</Text>;
+                        }
+                    }}
+                </ParentSize>
+                {/*<Text>{visualisationType}</Text>*/}
             </Pane>
         </Card>
     );

--- a/src/components/molecules/DataResultItem.tsx
+++ b/src/components/molecules/DataResultItem.tsx
@@ -15,7 +15,7 @@ export type DataResultItemProps = {
 };
 
 const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tags, visualisationType }) => {
-    const timeEntryMockData = mockTimeEntry(100, undefined);
+    const timeEntryMockData = mockTimeEntry(100);
 
     return (
         <Card

--- a/src/components/molecules/DataResultItem.tsx
+++ b/src/components/molecules/DataResultItem.tsx
@@ -54,7 +54,6 @@ const DataResultItem: React.FC<DataResultItemProps> = ({ title, description, tag
                                         width={parent.width}
                                         height={height > 0 ? height : parent.height}
                                         data={timeEntryMockData}
-                                        thresholdValue={undefined}
                                         yLabel="Threshold chart"
                                     />
                                 );

--- a/src/stories/DataResultItem.stories.tsx
+++ b/src/stories/DataResultItem.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import { Story } from '@storybook/react';
 import DataResultItem, { DataResultItemProps } from '../components/molecules/DataResultItem';
+import { VisualisationType } from '../types/Metadata';
 
 export default {
     title: 'DataExplorer/Result item',
@@ -12,11 +13,11 @@ const Template: Story<DataResultItemProps> = (args) => <DataResultItem {...args}
 
 export const Primary = Template.bind({});
 Primary.args = {
-    title: 'This is an title',
+    title: 'This is a title',
     description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
     tags: ['Energi', 'Miljø', 'Helse', 'Pils', 'Raketter'],
-    visualisationType: 'thresholdchart',
+    visualisationType: VisualisationType.THRESHOLD, // 'thresholdchart',
 };
 Primary.argTypes = {
     tags: { control: { type: 'array' } },

--- a/src/stories/DataResultItem.stories.tsx
+++ b/src/stories/DataResultItem.stories.tsx
@@ -17,7 +17,7 @@ Primary.args = {
     description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
     tags: ['Energi', 'Miljø', 'Helse', 'Pils', 'Raketter'],
-    visualisationType: VisualisationType.THRESHOLD, // 'thresholdchart',
+    visualisationType: VisualisationType.THRESHOLD,
 };
 Primary.argTypes = {
     tags: { control: { type: 'array' } },


### PR DESCRIPTION
Add charts with mocked data in the data source selection page.
Make use of the VisualisationType enum instead of just string matching.

Closes #109 