### PR TITLE
Fix firefox visualisation preview bug

### DIFF
--- a/src/components/molecules/VisualisationPreview.tsx
+++ b/src/components/molecules/VisualisationPreview.tsx
@@ -81,13 +81,20 @@ const VisualisationPreview: React.FC<VisualisationPreviewProps> = ({ metadata, s
         return null;
     }
 
+    const getSizeInPercentage = () => {
+        switch (size) {
+            case DashboardItemSize.LARGE:
+                return '100%';
+            case DashboardItemSize.MEDIUM:
+                return '75%';
+            case DashboardItemSize.SMALL:
+                return '50%';
+        }
+    };
+
     return (
         <>
-            {size !== DashboardItemSize.LARGE && (
-                //Spacer for smaller sizes
-                <Pane gridColumn={`span ${4 - size}`} />
-            )}
-            <Pane gridColumn={`span ${size}`} display="flex" flexDirection="column">
+            <Pane gridColumn="span 4" display="flex" flexDirection="column">
                 <Pane display="flex" flexDirection="row" marginBottom="1rem" flexWrap="wrap">
                     <Heading size={400}>
                         Forhåndsvisning
@@ -112,7 +119,7 @@ const VisualisationPreview: React.FC<VisualisationPreviewProps> = ({ metadata, s
                     <DashboardItem
                         title={metadata.name}
                         height="20rem"
-                        width="100%"
+                        width={getSizeInPercentage()}
                         titleSize={100}
                         paragraph={paragraph}
                     >

--- a/src/components/molecules/VisualisationPreview.tsx
+++ b/src/components/molecules/VisualisationPreview.tsx
@@ -94,8 +94,8 @@ const VisualisationPreview: React.FC<VisualisationPreviewProps> = ({ metadata, s
 
     return (
         <>
-            <Pane gridColumn="span 4" display="flex" flexDirection="column">
-                <Pane display="flex" flexDirection="row" marginBottom="1rem" flexWrap="wrap">
+            <Pane gridColumn="span 4" display="flex" flexDirection="column" width="100%">
+                <Pane display="flex" flexDirection="row" marginBottom="1rem">
                     <Heading size={400}>
                         Forhåndsvisning
                         <Tooltip content="Forhåndsvisningen er kun ment som referanse. Størrelse og endelig data vil endres i dashbordet.">
@@ -123,7 +123,7 @@ const VisualisationPreview: React.FC<VisualisationPreviewProps> = ({ metadata, s
                         titleSize={100}
                         paragraph={paragraph}
                     >
-                        <ParentSize>
+                        <ParentSize debounceTime={400}>
                             {(parent) => {
                                 return child(parent.width, parent.height);
                             }}

--- a/src/components/organisms/VisualisationEditor.tsx
+++ b/src/components/organisms/VisualisationEditor.tsx
@@ -41,7 +41,6 @@ const VisualisationEditor: React.FC = () => {
     return (
         <Pane
             width="100%"
-            height="25rem"
             display="grid"
             gridTemplateColumns="1fr 1fr 1fr 1fr 1fr 1fr"
             columnGap="1rem"


### PR DESCRIPTION
Changed how the visualisation preview css works by using flex and % instead of a hacky grid solution. This should work on firefox, chrome and safari now.  I don't like how the "Legg til i dashboard" button is placed when the visualisation is medium or small. Do you @thomran have any suggestions on how to fix this?  

Close #110 