### PR TITLE
Set selected visualisation if added to global store

### DIFF
--- a/src/components/atoms/VisualisationSelector.tsx
+++ b/src/components/atoms/VisualisationSelector.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { SelectField } from 'evergreen-ui';
+import { VisualisationType } from '../../types/Metadata';
 
 type Props = {
+    default: VisualisationType;
     label: string;
     options: Record<string, string>;
     onChange: React.ChangeEventHandler<HTMLSelectElement>;
 };
 
 const VisualisationSelector: React.FC<Props> = (props) => (
-    <SelectField label={props.label} defaultValue={Object.values(props.options)[0]} onChange={props.onChange}>
+    <SelectField label={props.label} value={props.default} onChange={props.onChange}>
         {Object.entries(props.options).map(([label, value]) => (
             <option key={value} value={value}>
                 {label}

--- a/src/components/organisms/VisualisationEditor.tsx
+++ b/src/components/organisms/VisualisationEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Pane, Text } from 'evergreen-ui';
-import { useQuery } from '@apollo/client';
+import { useQuery, useReactiveVar } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 import { AllMetadataResult, METADATA } from '../../queries/metadata';
 
@@ -9,15 +9,24 @@ import DataInfoBox from '../atoms/DatasetInfoBox';
 import VisualisationSelector from '../atoms/VisualisationSelector';
 import { friendlyNameForVisualisationType } from '../../utils/visualisationLabels';
 import { VisualisationType } from '../../types/Metadata';
+import { dashboardItemsVar } from '../../cache';
 
 const VisualisationEditor: React.FC = () => {
     const { loading, data, error } = useQuery<AllMetadataResult>(METADATA);
     const { id } = useParams<{ id: string }>();
+    const dashboardItems = useReactiveVar(dashboardItemsVar);
 
     const [selectedVisualisation, setSelectedVisualisation] = useState<VisualisationType>();
 
     // Default to first available visualisation
     useEffect(() => {
+        if (dashboardItems) {
+            const item = dashboardItems.find((el) => el.id === id);
+            if (item?.visualisationType) {
+                setSelectedVisualisation(item.visualisationType);
+                return;
+            }
+        }
         if (!data) return;
         setSelectedVisualisation(metadata.visualisations[0].type);
     }, [data]);
@@ -58,6 +67,7 @@ const VisualisationEditor: React.FC = () => {
             />
             <VisualisationSelector
                 label="Velg visualisering"
+                default={selectedVisualisation as VisualisationType}
                 options={Object.fromEntries(
                     metadata.visualisations.map((value) => [friendlyNameForVisualisationType(value.type), value.type]),
                 )}


### PR DESCRIPTION
Saves the selected visualisation when you refresh the visualisation editor page. Will also save the visualisation if you go to an visualisation in the data explorer you have already added.