### PR TITLE
🪂  Allow user to enter data source variables on visualisationeditor page

### DIFF
--- a/src/components/atoms/LatLonInputSet.tsx
+++ b/src/components/atoms/LatLonInputSet.tsx
@@ -1,0 +1,29 @@
+import React, { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { MetAPIVariables } from '../../queries/metApi';
+import { TextInputField } from 'evergreen-ui';
+
+type LatLonInputSetProps = {
+    state: MetAPIVariables;
+    setState: Dispatch<SetStateAction<MetAPIVariables>>;
+};
+
+const LatLonInputSet: React.FC<LatLonInputSetProps> = (props) => {
+    const [state, setState] = useState<{ lat: string; lon: string }>({ lat: '63', lon: '11' });
+
+    // To avoid problems with difficult digit entry for user
+    useEffect(() => {
+        props.setState({ lat: Number(state.lat), lon: Number(state.lon) });
+    }, [state]);
+
+    const update = (key: keyof typeof state) => (e: ChangeEvent<HTMLInputElement>) =>
+        setState((prevState) => ({ ...prevState, [key]: e.target.value }));
+
+    return (
+        <>
+            <TextInputField value={state.lat} label="Lengdegrad" onChange={update('lat')} />
+            <TextInputField value={state.lon} label="Breddegrad" onChange={update('lon')} />
+        </>
+    );
+};
+
+export default LatLonInputSet;

--- a/src/components/atoms/LatLonInputSet.tsx
+++ b/src/components/atoms/LatLonInputSet.tsx
@@ -20,8 +20,8 @@ const LatLonInputSet: React.FC<LatLonInputSetProps> = (props) => {
 
     return (
         <>
-            <TextInputField value={state.lat} label="Lengdegrad" onChange={update('lat')} />
-            <TextInputField value={state.lon} label="Breddegrad" onChange={update('lon')} />
+            <TextInputField value={state.lat} label="Breddegrad" onChange={update('lat')} />
+            <TextInputField value={state.lon} label="Lengdegrad" onChange={update('lon')} />
         </>
     );
 };

--- a/src/components/atoms/MunicipalitySelector.tsx
+++ b/src/components/atoms/MunicipalitySelector.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { SelectField } from 'evergreen-ui';
+
+type Props = {
+    label: string;
+    options: [string, string][];
+    onChange: React.ChangeEventHandler<HTMLSelectElement>;
+};
+
+const MunicipalitySelector: React.FC<Props> = (props) => (
+    <SelectField label={props.label} onChange={props.onChange}>
+        {Object.values(props.options).map(([municipalityKey, municipalityName]) => (
+            <option key={municipalityKey} value={municipalityKey}>
+                {municipalityName}
+            </option>
+        ))}
+    </SelectField>
+);
+
+export default MunicipalitySelector;

--- a/src/components/atoms/VisualisationParameterSelector.tsx
+++ b/src/components/atoms/VisualisationParameterSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Pane, SelectField, Textarea, Label } from 'evergreen-ui';
-import { DashboardItemSize } from '../../types/DashboardVisualisation';
+import { DashboardItemSize } from '../../types/VisualisationOption';
 
 type VisualisationParameterSelectorProps = {
     paragraph?: string;

--- a/src/components/molecules/DataSourceOptions.tsx
+++ b/src/components/molecules/DataSourceOptions.tsx
@@ -1,0 +1,44 @@
+import React, { Dispatch, SetStateAction, useMemo } from 'react';
+import { Heading, Pane } from 'evergreen-ui';
+import { DataSourceID, DataSourceVariables } from '../../types/DataSource';
+import MunicipalityEditor from './MunicipalityEditor';
+import { SSBPopulationVariables } from '../../queries/populationInNorway';
+import LatLonInputSet from '../atoms/LatLonInputSet';
+import { MetAPIVariables } from '../../queries/metApi';
+
+type DataSourceOptionsProps = {
+    state: DataSourceVariables;
+    setState: Dispatch<SetStateAction<DataSourceVariables>>;
+
+    dataSource: DataSourceID;
+};
+
+const DataSourceOptions: React.FC<DataSourceOptionsProps> = (props) => {
+    const child = useMemo(() => {
+        switch (props.dataSource) {
+            case DataSourceID.SSB_POPULATION:
+                return (
+                    <MunicipalityEditor setState={props.setState as Dispatch<SetStateAction<SSBPopulationVariables>>} />
+                );
+            case DataSourceID.MET_API_FORECAST:
+                return (
+                    <LatLonInputSet
+                        state={props.state as MetAPIVariables}
+                        setState={props.setState as Dispatch<SetStateAction<MetAPIVariables>>}
+                    />
+                );
+        }
+    }, [props]);
+
+    return (
+        <Pane gridColumn="span 2">
+            <Heading size={500} marginBottom="1em">
+                Parametere
+            </Heading>
+
+            {child}
+        </Pane>
+    );
+};
+
+export default DataSourceOptions;

--- a/src/components/molecules/DataWrapper.tsx
+++ b/src/components/molecules/DataWrapper.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { DocumentNode, useQuery } from '@apollo/client';
 import Loading from '../atoms/Loading';
 import ErrorMessage from '../atoms/ErrorMessage';
+import { DataSourceVariables } from '../../types/DataSource';
 
 /**
  * @param T The raw output of the GraphQL query.
@@ -11,6 +12,7 @@ export type DataWrapperProps<T, U> = {
     query: DocumentNode;
     children: (data: U) => ReactElement;
     mappingFunction: (data: T) => U;
+    variables: DataSourceVariables;
 };
 
 /**
@@ -19,7 +21,7 @@ export type DataWrapperProps<T, U> = {
  */
 
 const DataWrapper = <T, U>(props: DataWrapperProps<T, U>): ReactElement => {
-    const { loading, error, data } = useQuery<T>(props.query);
+    const { loading, error, data } = useQuery<T>(props.query, { variables: props.variables });
 
     if (loading) {
         return <Loading />;

--- a/src/components/molecules/MunicipalityEditor.tsx
+++ b/src/components/molecules/MunicipalityEditor.tsx
@@ -1,0 +1,40 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import { useQuery } from '@apollo/client';
+import { Combobox, Text } from 'evergreen-ui';
+import MunicipalitySelector from '../atoms/MunicipalitySelector';
+import { MUNICIPALITIES_IN_NORWAY, MunicipalitiesInNorway } from '../../queries/municipalitiesInNorway';
+import { SSBPopulationVariables } from '../../queries/populationInNorway';
+
+export type MunicipalityEditorProps = {
+    setState: Dispatch<SetStateAction<SSBPopulationVariables>>;
+};
+
+const MunicipalityEditor: React.FC<MunicipalityEditorProps> = (props) => {
+    const { loading, data, error } = useQuery<MunicipalitiesInNorway>(MUNICIPALITIES_IN_NORWAY);
+
+    if (error) {
+        return <Text>{error.message}</Text>;
+    }
+
+    if (loading) {
+        return <Combobox isLoading disabled items={['Loading']} />;
+    }
+
+    if (!data) {
+        return <Text>Empty</Text>;
+    }
+
+    const setMunicipality = (name: string) => {
+        props.setState({ municipalities: [name] });
+    };
+
+    return (
+        <MunicipalitySelector
+            label="Velg kommune"
+            options={data.populationsInNorway.municipalitiesWithKeys}
+            onChange={(selected) => setMunicipality(selected.currentTarget.value as string)}
+        />
+    );
+};
+
+export default MunicipalityEditor;

--- a/src/components/molecules/MunicipalityEditor.tsx
+++ b/src/components/molecules/MunicipalityEditor.tsx
@@ -21,7 +21,7 @@ const MunicipalityEditor: React.FC<MunicipalityEditorProps> = (props) => {
     }
 
     if (!data) {
-        return <Text>Empty</Text>;
+        return <Text>Tomt</Text>;
     }
 
     const setMunicipality = (name: string) => {

--- a/src/components/molecules/VisualisationPreview.tsx
+++ b/src/components/molecules/VisualisationPreview.tsx
@@ -4,8 +4,8 @@ import { Heading, InfoSignIcon, Pane, Tooltip, Text } from 'evergreen-ui';
 import { MetadataEntry } from '../../queries/metadata';
 import DashboardItem from './DashboardItem';
 import { VisualisationType } from '../../types/Metadata';
-import { DashboardItemSize } from '../../types/DashboardVisualisation';
 import MockedVisualisation from './MockedVisualisation';
+import { DashboardItemSize } from '../../types/VisualisationOption';
 
 type VisualisationPreviewProps = {
     metadata: MetadataEntry;

--- a/src/components/organisms/DashboardItems.tsx
+++ b/src/components/organisms/DashboardItems.tsx
@@ -70,6 +70,7 @@ const DashboardItems: React.FC = () => {
                             <DataWrapper
                                 mappingFunction={visualisationMapping[mappingPath as VisualisationMappingFunctionPath]}
                                 query={queries[visualisation.dataSourceId]}
+                                variables={visualisation.variables}
                             >
                                 {(data) => {
                                     const Vis = Visualisations[visualisation.visualisationType];

--- a/src/components/pages/VisualisationEditor.tsx
+++ b/src/components/pages/VisualisationEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Button, CircleArrowLeftIcon, Pane, Text } from 'evergreen-ui';
 import { useQuery } from '@apollo/client';
 import { useParams } from 'react-router-dom';
@@ -14,6 +14,8 @@ import { useHistory } from 'react-router';
 import AddToDashboard from '../molecules/AddToDashboard';
 import VisualisationParameterSelector from '../atoms/VisualisationParameterSelector';
 import { DashboardItemSize } from '../../types/VisualisationOption';
+import DataSourceOptions from '../molecules/DataSourceOptions';
+import { defaultVariables, DataSourceVariables } from '../../types/DataSource';
 
 const VisualisationEditor: React.FC = () => {
     const { loading, data, error } = useQuery<AllMetadataResult>(METADATA);
@@ -24,6 +26,8 @@ const VisualisationEditor: React.FC = () => {
 
     const [paragraph, setParagraph] = useState<string>();
     const [size, setSize] = useState<DashboardItemSize>(DashboardItemSize.LARGE);
+
+    const [variables, setVariables] = useState<DataSourceVariables>();
 
     if (error) {
         return <Text>{error.message}</Text>;
@@ -44,7 +48,14 @@ const VisualisationEditor: React.FC = () => {
     const metadata = data.allMetadata.find((el) => el.id === id)!;
 
     // Set the first available visualisation to active
-    useEffect(() => setSelectedVisualisation(metadata.visualisations[0].type), [metadata]);
+    useEffect(() => {
+        setSelectedVisualisation(metadata.visualisations[0].type);
+        setVariables(defaultVariables[metadata.datasourceId]);
+    }, [metadata]);
+
+    if (variables === undefined) {
+        return null;
+    }
 
     return (
         <>
@@ -93,9 +104,15 @@ const VisualisationEditor: React.FC = () => {
                             visualisationType: selectedVisualisation ?? metadata.visualisations[0].type,
                             dataSourceId: metadata.datasourceId,
                             options: { size, paragraph },
+                            variables,
                         }}
                     />
                 </Pane>
+                <DataSourceOptions
+                    state={variables}
+                    setState={setVariables as Dispatch<SetStateAction<DataSourceVariables>>}
+                    dataSource={metadata.datasourceId}
+                />
             </Pane>
         </>
     );

--- a/src/components/pages/VisualisationEditor.tsx
+++ b/src/components/pages/VisualisationEditor.tsx
@@ -1,23 +1,30 @@
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Button, CircleArrowLeftIcon, Pane, Text } from 'evergreen-ui';
-import { useQuery } from '@apollo/client';
+
 import { useParams } from 'react-router-dom';
+import { useHistory } from 'react-router';
+
+import { RootState } from '../../redux';
+import { useSelector } from 'react-redux';
+
+import { useQuery } from '@apollo/client';
+
 import { AllMetadataResult, METADATA } from '../../queries/metadata';
 
-import VisualisationPreview from '../molecules/VisualisationPreview';
+import { friendlyNameForVisualisationType } from '../../utils/visualisationLabels';
+
+import { VisualisationType } from '../../types/Metadata';
+import { DashboardItemSize } from '../../types/VisualisationOption';
+import { DataSourceVariables, defaultVariables } from '../../types/DataSource';
+
 import DataInfoBox from '../atoms/DatasetInfoBox';
 import VisualisationSelector from '../atoms/VisualisationSelector';
-import { friendlyNameForVisualisationType } from '../../utils/visualisationLabels';
-import { VisualisationType } from '../../types/Metadata';
-
-import { useHistory } from 'react-router';
-import AddToDashboard from '../molecules/AddToDashboard';
 import VisualisationParameterSelector from '../atoms/VisualisationParameterSelector';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../redux';
-import { DashboardItemSize } from '../../types/VisualisationOption';
+
+import VisualisationPreview from '../molecules/VisualisationPreview';
+import AddToDashboard from '../molecules/AddToDashboard';
 import DataSourceOptions from '../molecules/DataSourceOptions';
-import { defaultVariables, DataSourceVariables } from '../../types/DataSource';
+
+import { Button, CircleArrowLeftIcon, Pane, Text } from 'evergreen-ui';
 
 const VisualisationEditor: React.FC = () => {
     const { loading, data, error } = useQuery<AllMetadataResult>(METADATA);

--- a/src/components/pages/VisualisationEditor.tsx
+++ b/src/components/pages/VisualisationEditor.tsx
@@ -12,8 +12,8 @@ import { VisualisationType } from '../../types/Metadata';
 
 import { useHistory } from 'react-router';
 import AddToDashboard from '../molecules/AddToDashboard';
-import { DashboardItemSize } from '../../types/DashboardVisualisation';
 import VisualisationParameterSelector from '../atoms/VisualisationParameterSelector';
+import { DashboardItemSize } from '../../types/VisualisationOption';
 
 const VisualisationEditor: React.FC = () => {
     const { loading, data, error } = useQuery<AllMetadataResult>(METADATA);

--- a/src/npm/components/MetApi.tsx
+++ b/src/npm/components/MetApi.tsx
@@ -4,11 +4,22 @@ import LineChart, { LineChartProps } from '../../components/visualisations/LineC
 import ThresholdChart, { ThresholdChartProps } from '../../components/visualisations/ThresholdChart';
 import DataWrapper from '../../components/molecules/DataWrapper';
 import visualisationMapping from '../../utils/visualisationMapping';
-import { WEATHER_MET_API } from '../../queries/metApi';
+import { MetAPIVariables, WEATHER_MET_API } from '../../queries/metApi';
 
-const MetApiLine: React.FC<Omit<LineChartProps, 'data'>> = ({ yLabel, strokeColor, height, width }) => {
+const MetApiLine: React.FC<Omit<LineChartProps, 'data'> & MetAPIVariables> = ({
+    yLabel,
+    strokeColor,
+    height,
+    width,
+    lat,
+    lon,
+}) => {
     return (
-        <DataWrapper mappingFunction={visualisationMapping[`MET_API-linechart`]} query={WEATHER_MET_API}>
+        <DataWrapper
+            mappingFunction={visualisationMapping[`MET_API-linechart`]}
+            query={WEATHER_MET_API}
+            variables={{ lat, lon }}
+        >
             {(data) => (
                 <LineChart data={data} yLabel={yLabel} strokeColor={strokeColor} height={height} width={width} />
             )}
@@ -16,16 +27,22 @@ const MetApiLine: React.FC<Omit<LineChartProps, 'data'>> = ({ yLabel, strokeColo
     );
 };
 
-const MetApiThreshold: React.FC<Omit<ThresholdChartProps, 'data'>> = ({
+const MetApiThreshold: React.FC<Omit<ThresholdChartProps, 'data'> & MetAPIVariables> = ({
     thresholdValue,
     aboveThresholdColor,
     belowThresholdColor,
     yLabel,
     height,
     width,
+    lat,
+    lon,
 }) => {
     return (
-        <DataWrapper mappingFunction={visualisationMapping[`MET_API-thresholdchart`]} query={WEATHER_MET_API}>
+        <DataWrapper
+            mappingFunction={visualisationMapping[`MET_API-thresholdchart`]}
+            query={WEATHER_MET_API}
+            variables={{ lat, lon }}
+        >
             {(data) => (
                 <ThresholdChart
                     data={data}

--- a/src/npm/components/SsbBefolkning.tsx
+++ b/src/npm/components/SsbBefolkning.tsx
@@ -4,11 +4,21 @@ import LineChart, { LineChartProps } from '../../components/visualisations/LineC
 import ThresholdChart, { ThresholdChartProps } from '../../components/visualisations/ThresholdChart';
 import DataWrapper from '../../components/molecules/DataWrapper';
 import visualisationMapping from '../../utils/visualisationMapping';
-import { POPULATION_IN_NORWAY } from '../../queries/populationInNorway';
+import { POPULATION_IN_NORWAY, SSBPopulationVariables } from '../../queries/populationInNorway';
 
-const SsbBefolkningLine: React.FC<Omit<LineChartProps, 'data'>> = ({ yLabel, strokeColor, height, width }) => {
+const SsbBefolkningLine: React.FC<Omit<LineChartProps, 'data'> & SSBPopulationVariables> = ({
+    municipalities,
+    yLabel,
+    strokeColor,
+    height,
+    width,
+}) => {
     return (
-        <DataWrapper mappingFunction={visualisationMapping[`SSB_POPULATION-linechart`]} query={POPULATION_IN_NORWAY}>
+        <DataWrapper
+            mappingFunction={visualisationMapping[`SSB_POPULATION-linechart`]}
+            query={POPULATION_IN_NORWAY}
+            variables={{ municipalities }}
+        >
             {(data) => (
                 <LineChart data={data} yLabel={yLabel} strokeColor={strokeColor} height={height} width={width} />
             )}
@@ -16,7 +26,7 @@ const SsbBefolkningLine: React.FC<Omit<LineChartProps, 'data'>> = ({ yLabel, str
     );
 };
 
-const SsbBefolkningThreshold: React.FC<Omit<ThresholdChartProps, 'data'>> = ({
+const SsbBefolkningThreshold: React.FC<Omit<ThresholdChartProps, 'data'> & SSBPopulationVariables> = ({
     strokeColor,
     aboveThresholdColor,
     belowThresholdColor,
@@ -24,11 +34,13 @@ const SsbBefolkningThreshold: React.FC<Omit<ThresholdChartProps, 'data'>> = ({
     yLabel,
     height,
     width,
+    municipalities,
 }) => {
     return (
         <DataWrapper
             mappingFunction={visualisationMapping[`SSB_POPULATION-thresholdchart`]}
             query={POPULATION_IN_NORWAY}
+            variables={{ municipalities }}
         >
             {(data) => (
                 <ThresholdChart

--- a/src/queries/metApi.ts
+++ b/src/queries/metApi.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const WEATHER_MET_API = gql`
-    query {
-        forecast {
+    query($lat: Float, $lon: Float) {
+        forecast(lat: $lat, lon: $lon) {
             forecastProperties {
                 meta {
                     updatedAt
@@ -40,4 +40,9 @@ export type MetApiCompactAirTemperature = {
             }[];
         };
     };
+};
+
+export type MetAPIVariables = {
+    lat: number;
+    lon: number;
 };

--- a/src/queries/municipalitiesInNorway.ts
+++ b/src/queries/municipalitiesInNorway.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+
+export const MUNICIPALITIES_IN_NORWAY = gql`
+    query {
+        populationsInNorway {
+            municipalitiesWithKeys
+        }
+    }
+`;
+
+export type MunicipalitiesInNorway = {
+    populationsInNorway: {
+        municipalitiesWithKeys: [string, string][];
+    };
+};

--- a/src/queries/populationInNorway.ts
+++ b/src/queries/populationInNorway.ts
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client';
 
 export const POPULATION_IN_NORWAY = gql`
-    query {
+    query($municipalities: [String]) {
         populationsInNorway {
-            dataset(years: ["2014", "2015", "2016", "2017", "2018", "2019", "2020"], municipalities: ["K-0301"]) {
+            dataset(years: ["2014", "2015", "2016", "2017", "2018", "2019", "2020"], municipalities: $municipalities) {
                 value {
                     populationForYear {
                         population
@@ -26,4 +26,8 @@ export type PopulationInNorway = {
             }[];
         };
     };
+};
+
+export type SSBPopulationVariables = {
+    municipalities: string[];
 };

--- a/src/stories/VisualisationPreview.stories.tsx
+++ b/src/stories/VisualisationPreview.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 import VisualisationPreview from '../components/molecules/VisualisationPreview';
 import { makeMetadata } from '../mockdata/mocks';
 import { VisualisationType } from '../types/Metadata';
-import { DashboardItemSize } from '../types/DashboardVisualisation';
+import { DashboardItemSize } from '../types/VisualisationOption';
 
 export default {
     title: 'Visualisation editor/Visualisation preview',

--- a/src/types/DashboardVisualisation.ts
+++ b/src/types/DashboardVisualisation.ts
@@ -1,4 +1,4 @@
-import { DataSourceID } from './DataSource';
+import { DataSourceID, DataSourceVariables } from './DataSource';
 import { VisualisationType } from './Metadata';
 import { ChartCustomisationOption } from './VisualisationOption';
 
@@ -10,4 +10,5 @@ export type DashboardVisualisation = {
     dataSourceId: DataSourceID;
     visualisationType: VisualisationType;
     options: ChartCustomisationOption;
+    variables: DataSourceVariables;
 };

--- a/src/types/DashboardVisualisation.ts
+++ b/src/types/DashboardVisualisation.ts
@@ -1,29 +1,10 @@
 import { DataSourceID } from './DataSource';
 import { VisualisationType } from './Metadata';
-
-/**
- * Visualisation customisation
- */
-
-// This is the set of options for all visualisations
-export type BaseChartCustomisationOption = { description?: string; size: DashboardItemSize; paragraph?: string };
-
-// Add a customisation option for each visualisation possible
-export type LineChartCustomisationOption = BaseChartCustomisationOption;
-export type ThresholdChartCustomisationOption = BaseChartCustomisationOption & { thresholdValue?: number };
-
-// The union type of all available customisation option objects
-export type ChartCustomisationOption = LineChartCustomisationOption | ThresholdChartCustomisationOption;
+import { ChartCustomisationOption } from './VisualisationOption';
 
 /**
  * General
  */
-
-export enum DashboardItemSize {
-    SMALL = 2,
-    MEDIUM = 4,
-    LARGE = 6,
-}
 
 export type DashboardVisualisation = {
     dataSourceId: DataSourceID;

--- a/src/types/DataSource.ts
+++ b/src/types/DataSource.ts
@@ -1,4 +1,22 @@
+import { SSBPopulationVariables } from '../queries/populationInNorway';
+import { MetAPIVariables } from '../queries/metApi';
+
 export enum DataSourceID {
     SSB_POPULATION = 'SSB_POPULATION',
     MET_API_FORECAST = 'MET_API',
 }
+
+export const defaultVariables: Record<DataSourceID, DataSourceVariables> = {
+    [DataSourceID.SSB_POPULATION]: {
+        municipalities: ['K-0301'],
+    },
+    [DataSourceID.MET_API_FORECAST]: {
+        lat: 63,
+        lon: 11,
+    },
+};
+
+/**
+ * Main exports
+ */
+export type DataSourceVariables = SSBPopulationVariables | MetAPIVariables;

--- a/src/types/VisualisationOption.ts
+++ b/src/types/VisualisationOption.ts
@@ -1,0 +1,19 @@
+export enum DashboardItemSize {
+    SMALL = 2,
+    MEDIUM = 4,
+    LARGE = 6,
+}
+
+/**
+ * Visualisation customisation
+ */
+
+// This is the set of options for all visualisations
+export type BaseChartCustomisationOption = { description?: string; size: DashboardItemSize; paragraph?: string };
+
+// Add a customisation option for each visualisation possible
+export type LineChartCustomisationOption = BaseChartCustomisationOption;
+export type ThresholdChartCustomisationOption = BaseChartCustomisationOption & { thresholdValue?: number };
+
+// The union type of all available customisation option objects
+export type ChartCustomisationOption = LineChartCustomisationOption | ThresholdChartCustomisationOption;


### PR DESCRIPTION
Closes #116 
Closes #141 


--------
Stole the municipality logic from #116 (@fredrikbw).

On the visualisation editor page you can now see options for each data source and customise these to your liking. These parameters will then be included in the queries to the backend.