### PR TITLE
Hydrate edit page with variables

### DIFF
--- a/src/components/atoms/LatLonInputSet.tsx
+++ b/src/components/atoms/LatLonInputSet.tsx
@@ -8,7 +8,10 @@ type LatLonInputSetProps = {
 };
 
 const LatLonInputSet: React.FC<LatLonInputSetProps> = (props) => {
-    const [state, setState] = useState<{ lat: string; lon: string }>({ lat: '63', lon: '11' });
+    const [state, setState] = useState<{ lat: string; lon: string }>({
+        lat: String(props.state.lat),
+        lon: String(props.state.lon),
+    });
 
     // To avoid problems with difficult digit entry for user
     useEffect(() => {

--- a/src/components/atoms/MunicipalitySelector.tsx
+++ b/src/components/atoms/MunicipalitySelector.tsx
@@ -5,10 +5,11 @@ type Props = {
     label: string;
     options: [string, string][];
     onChange: React.ChangeEventHandler<HTMLSelectElement>;
+    defaultValue: string;
 };
 
 const MunicipalitySelector: React.FC<Props> = (props) => (
-    <SelectField label={props.label} onChange={props.onChange}>
+    <SelectField label={props.label} onChange={props.onChange} defaultValue={props.defaultValue}>
         {Object.values(props.options).map(([municipalityKey, municipalityName]) => (
             <option key={municipalityKey} value={municipalityKey}>
                 {municipalityName}

--- a/src/components/molecules/DataSourceOptions.tsx
+++ b/src/components/molecules/DataSourceOptions.tsx
@@ -18,7 +18,10 @@ const DataSourceOptions: React.FC<DataSourceOptionsProps> = (props) => {
         switch (props.dataSource) {
             case DataSourceID.SSB_POPULATION:
                 return (
-                    <MunicipalityEditor setState={props.setState as Dispatch<SetStateAction<SSBPopulationVariables>>} />
+                    <MunicipalityEditor
+                        state={props.state as SSBPopulationVariables}
+                        setState={props.setState as Dispatch<SetStateAction<SSBPopulationVariables>>}
+                    />
                 );
             case DataSourceID.MET_API_FORECAST:
                 return (

--- a/src/components/molecules/MunicipalityEditor.tsx
+++ b/src/components/molecules/MunicipalityEditor.tsx
@@ -6,6 +6,7 @@ import { MUNICIPALITIES_IN_NORWAY, MunicipalitiesInNorway } from '../../queries/
 import { SSBPopulationVariables } from '../../queries/populationInNorway';
 
 export type MunicipalityEditorProps = {
+    state: SSBPopulationVariables;
     setState: Dispatch<SetStateAction<SSBPopulationVariables>>;
 };
 
@@ -30,6 +31,7 @@ const MunicipalityEditor: React.FC<MunicipalityEditorProps> = (props) => {
 
     return (
         <MunicipalitySelector
+            defaultValue={props.state.municipalities[0]}
             label="Velg kommune"
             options={data.populationsInNorway.municipalitiesWithKeys}
             onChange={(selected) => setMunicipality(selected.currentTarget.value as string)}

--- a/src/components/pages/VisualisationEditor.tsx
+++ b/src/components/pages/VisualisationEditor.tsx
@@ -25,6 +25,7 @@ import AddToDashboard from '../molecules/AddToDashboard';
 import DataSourceOptions from '../molecules/DataSourceOptions';
 
 import { Button, CircleArrowLeftIcon, Pane, Text } from 'evergreen-ui';
+import { DashboardVisualisation } from '../../types/DashboardVisualisation';
 
 const VisualisationEditor: React.FC = () => {
     const { loading, data, error } = useQuery<AllMetadataResult>(METADATA);
@@ -33,7 +34,7 @@ const VisualisationEditor: React.FC = () => {
 
     const [selectedVisualisation, setSelectedVisualisation] = useState<VisualisationType>();
 
-    const visualisation = useSelector((state: RootState) => state.dashboard[id]);
+    const visualisation = useSelector((state: RootState) => state.dashboard[id] as DashboardVisualisation | undefined);
 
     const [paragraph, setParagraph] = useState<string>();
     const [size, setSize] = useState<DashboardItemSize>(DashboardItemSize.LARGE);
@@ -64,8 +65,8 @@ const VisualisationEditor: React.FC = () => {
 
     // Set the first available visualisation to active
     useEffect(() => {
-        setSelectedVisualisation(metadata.visualisations[0].type);
-        setVariables(defaultVariables[metadata.datasourceId]);
+        setSelectedVisualisation(visualisation ? visualisation.visualisationType : metadata.visualisations[0].type);
+        setVariables(visualisation ? visualisation.variables : defaultVariables[metadata.datasourceId]);
     }, [metadata]);
 
     if (variables === undefined) {

--- a/src/components/pages/VisualisationEditor.tsx
+++ b/src/components/pages/VisualisationEditor.tsx
@@ -41,6 +41,18 @@ const VisualisationEditor: React.FC = () => {
 
     const [variables, setVariables] = useState<DataSourceVariables>();
 
+    const metadata = visualisation
+        ? data?.allMetadata.find((el) => el.datasourceId === visualisation.dataSourceId)
+        : data?.allMetadata.find((el) => el.id === id);
+
+    // Set the first available visualisation to active
+    useEffect(() => {
+        if (metadata === undefined) return;
+
+        setSelectedVisualisation(visualisation ? visualisation.visualisationType : metadata.visualisations[0].type);
+        setVariables(visualisation ? visualisation.variables : defaultVariables[metadata.datasourceId]);
+    }, [metadata, visualisation]);
+
     if (error) {
         return <Text>{error.message}</Text>;
     }
@@ -55,19 +67,9 @@ const VisualisationEditor: React.FC = () => {
         return null;
     }
 
-    const metadata = visualisation
-        ? data.allMetadata.find((el) => el.datasourceId === visualisation.dataSourceId)
-        : data.allMetadata.find((el) => el.id === id);
-
     if (!metadata) {
         return null;
     }
-
-    // Set the first available visualisation to active
-    useEffect(() => {
-        setSelectedVisualisation(visualisation ? visualisation.visualisationType : metadata.visualisations[0].type);
-        setVariables(visualisation ? visualisation.variables : defaultVariables[metadata.datasourceId]);
-    }, [metadata]);
 
     if (variables === undefined) {
         return null;


### PR DESCRIPTION
Closes #126 

------------

Changelog
------
- The edit page is now seeded with the values from the Redux store
- Moved effect that followed an if-statement causing errors on page refresh due to differing amount of hook invocations